### PR TITLE
fix: 토글 버튼 탭 전환 시 플리커 문제 수정

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -76,11 +76,10 @@ export function MainContent({ user, project }: MainContentProps) {
 
                 {/* Content Area */}
                 <div className="flex-1 overflow-hidden bg-neutral-50">
-                  {activeView === "preview" ? (
-                    <div className="h-full bg-white">
-                      <PreviewFrame />
-                    </div>
-                  ) : (
+                  <div className={activeView === "preview" ? "h-full bg-white" : "hidden"}>
+                    <PreviewFrame />
+                  </div>
+                  <div className={activeView === "code" ? "h-full" : "hidden"}>
                     <ResizablePanelGroup
                       direction="horizontal"
                       className="h-full"
@@ -105,7 +104,7 @@ export function MainContent({ user, project }: MainContentProps) {
                         </div>
                       </ResizablePanel>
                     </ResizablePanelGroup>
-                  )}
+                  </div>
                 </div>
               </div>
             </ResizablePanel>

--- a/src/components/preview/PreviewFrame.tsx
+++ b/src/components/preview/PreviewFrame.tsx
@@ -13,17 +13,12 @@ export function PreviewFrame() {
   const { getAllFiles, refreshTrigger } = useFileSystem();
   const [error, setError] = useState<string | null>(null);
   const [entryPoint, setEntryPoint] = useState<string>("/App.jsx");
-  const [isFirstLoad, setIsFirstLoad] = useState(true);
+  const isFirstLoadRef = useRef(true);
 
   useEffect(() => {
     const updatePreview = () => {
       try {
         const files = getAllFiles();
-
-        // Clear error first when we have files
-        if (files.size > 0 && error) {
-          setError(null);
-        }
 
         // Find the entry point - look for App.jsx, App.tsx, index.jsx, or index.tsx
         let foundEntryPoint = entryPoint;
@@ -54,18 +49,13 @@ export function PreviewFrame() {
         }
 
         if (files.size === 0) {
-          if (isFirstLoad) {
-            setError("firstLoad");
-          } else {
-            setError("No files to preview");
-          }
+          setError(isFirstLoadRef.current ? "firstLoad" : "No files to preview");
           return;
         }
 
         // We have files, so it's no longer the first load
-        if (isFirstLoad) {
-          setIsFirstLoad(false);
-        }
+        isFirstLoadRef.current = false;
+        setError(null);
 
         if (!foundEntryPoint || !files.has(foundEntryPoint)) {
           setError(
@@ -86,8 +76,6 @@ export function PreviewFrame() {
             "allow-scripts allow-same-origin allow-forms"
           );
           iframe.srcdoc = previewHTML;
-
-          setError(null);
         }
       } catch (err) {
         console.error("Preview error:", err);
@@ -96,7 +84,7 @@ export function PreviewFrame() {
     };
 
     updatePreview();
-  }, [refreshTrigger, getAllFiles, entryPoint, error, isFirstLoad]);
+  }, [refreshTrigger, getAllFiles, entryPoint]);
 
   if (error) {
     if (error === "firstLoad") {


### PR DESCRIPTION
Fixes #3

## Changes

- Replace conditional rendering with CSS display toggling so PreviewFrame and CodeEditor stay mounted when switching tabs
- Replace isFirstLoad state with a ref in PreviewFrame to avoid unnecessary re-renders
- Remove error and isFirstLoad from useEffect dependency array

Generated with [Claude Code](https://claude.ai/code)